### PR TITLE
fix: fling contentlayout will incorrectly perform the operation of translationY when headerview is expanded.

### DIFF
--- a/app/src/main/java/com/pengguanming/mimusicbehavior/behavior/ContentBehavior.java
+++ b/app/src/main/java/com/pengguanming/mimusicbehavior/behavior/ContentBehavior.java
@@ -149,7 +149,7 @@ public class ContentBehavior extends CoordinatorLayout.Behavior<View> {
                                   @NonNull View target, int dx, int dy, @NonNull int[] consumed, int type) {
         float transY = child.getTranslationY() - dy;
 
-        if (type == ViewCompat.TYPE_NON_TOUCH && !flingFromCollaps) {
+        if (type == ViewCompat.TYPE_NON_TOUCH && !flingFromCollaps && dy <= 0) {
             return;
         }
         

--- a/app/src/main/java/com/pengguanming/mimusicbehavior/behavior/ContentBehavior.java
+++ b/app/src/main/java/com/pengguanming/mimusicbehavior/behavior/ContentBehavior.java
@@ -149,6 +149,10 @@ public class ContentBehavior extends CoordinatorLayout.Behavior<View> {
                                   @NonNull View target, int dx, int dy, @NonNull int[] consumed, int type) {
         float transY = child.getTranslationY() - dy;
 
+        if (type == ViewCompat.TYPE_NON_TOUCH && !flingFromCollaps) {
+            return;
+        }
+        
         //处理上滑
         if (dy > 0) {
             if (transY >= topBarHeight) {


### PR DESCRIPTION
 Closes #2